### PR TITLE
Update vanilla nginx conf template

### DIFF
--- a/templates/sites/vanilla.conf.template
+++ b/templates/sites/vanilla.conf.template
@@ -103,6 +103,15 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
+    
+    location /manager {
+        proxy_pass http://dash:3000/manager;
+        proxy_redirect off;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
 }
 
 server {


### PR DESCRIPTION
Update vanilla nginx conf template to include the dash manager at /manager. This way, the manager will be enabled by default with wand, and clear up confusion.