### PR TITLE
Add manager to Legacy nginx Conf

### DIFF
--- a/templates/sites/legacy.conf.template
+++ b/templates/sites/legacy.conf.template
@@ -39,6 +39,15 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     }
+
+    location /manager {
+        proxy_pass http://dash:3000/manager;
+        proxy_redirect off;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
 }
 
 server {


### PR DESCRIPTION
Add a line to the legacy.nginx.conf file to enable access to the Dash Manager from the legacy domain, in case it is the only domain enabled.