### PR TITLE
Add dash configuration for card-jitsu snow

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -210,7 +210,7 @@ services:
     networks:
       - wand
     ports:
-      - ${SNOWFLAKE_HOST}:${SNOWFLAKE_PORT}:${SNOWFLAKE_PORT}
+      - ${SNOWFLAKE_PORT}:${SNOWFLAKE_PORT}
     env_file:
       - .env
     environment:

--- a/templates/dash/config.py.template
+++ b/templates/dash/config.py.template
@@ -157,5 +157,17 @@ LOGIN_FAILURE_TIMER = 3600
 LOGIN_FAILURE_LIMIT = 5
 
 
+"""
+Card-Jitsu Snow
+---------------
+CJS_HOST : str
+    External ip or domain of the Card-Jitsu Snow game server.
+CJS_PORT : int
+    Port of the Card-Jitsu Snow game server.
+"""
+CJS_HOST = '{{ .Env.SNOWFLAKE_HOST }}'
+CJS_PORT = {{ .Env.SNOWFLAKE_PORT }}
+
+
 # For more configuration settings see
 # https://sanic.readthedocs.io/en/latest/sanic/config.html#builtin-configuration-values


### PR DESCRIPTION
Here is a follow-up for [this pr](https://github.com/solero/dash/pull/41), which updates the dash config template to add the cjsnow section.