### PR TITLE
Updated .env example values

### DIFF
--- a/.env
+++ b/.env
@@ -131,7 +131,7 @@ WEB_RECAPTCHA_SECRET=
 ##############################################
 
 EMAIL_METHOD=
-EMAIL_FROM_ADDRESS=no-reply@ikea.fishing
+EMAIL_FROM_ADDRESS=no-reply@example.com
 
 EMAIL_SENDGRID_KEY=
 


### PR DESCRIPTION
Accidentally left my own domain in the example values in the `.env` file, this changes it to `example.com` instead.